### PR TITLE
pipeline refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@
 .Rhistory
 .RData
 .Ruserdata
+1_fetch/out/*
+3_visualize/out/*
 
 .remake/*

--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -1,5 +1,6 @@
-nwis_site_info <- function(fileout, site_data){
-  site_no <- unique(site_data$site_no)
+nwis_site_info <- function(fileout, site_hash_table){
+  site_no <- site_hash_table$filepath %>% basename() %>% 
+    stringr::str_extract(pattern = "(?:[0-9]+)")
   site_info <- dataRetrieval::readNWISsite(site_no)
   write_csv(site_info, fileout)
 }

--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -1,22 +1,3 @@
-
-download_nwis_data <- function(site_nums = c("01427207", "01432160", "01435000", "01436690", "01466500")){
-  
-  # create the file names that are needed for download_nwis_site_data
-  # tempdir() creates a temporary directory that is wiped out when you start a new R session; 
-  # replace tempdir() with "1_fetch/out" or another desired folder if you want to retain the download
-  download_files <- file.path(tempdir(), paste0('nwis_', site_nums, '_data.csv'))
-  data_out <- data.frame(agency_cd = c(), site_no = c(), dateTime = c(), 
-                         X_00010_00000 = c(), X_00010_00000_cd = c(), tz_cd = c())
-  # loop through files to download 
-  for (download_file in download_files){
-    download_nwis_site_data(download_file, parameterCd = '00010')
-    # read the downloaded data and append it to the existing data.frame
-    these_data <- read_csv(download_file, col_types = 'ccTdcc')
-    data_out <- rbind(data_out, these_data)
-  }
-  return(data_out)
-}
-
 nwis_site_info <- function(fileout, site_data){
   site_no <- unique(site_data$site_no)
   site_info <- dataRetrieval::readNWISsite(site_no)
@@ -32,14 +13,14 @@ download_nwis_site_data <- function(filepath, parameterCd = '00010', startDate="
     stringr::str_extract(pattern = "(?:[0-9]+)")
   
   # readNWISdata is from the dataRetrieval package
-  data_out <- readNWISdata(sites=site_num, service="iv", 
+  data_out <- readNWISdata(sites=site_num, 
+                           service="iv", 
                            parameterCd = parameterCd, startDate = startDate, endDate = endDate)
-
-  # -- simulating a failure-prone web-sevice here, do not edit --
+  #-- simulating a failure-prone web-sevice here, do not edit --
   if (sample(c(T,F,F,F), 1)){
     stop(site_num, ' has failed due to connection timeout. Try scmake() again')
   }
-  # -- end of do-not-edit block
+  #-- end of do-not-edit block
   
   write_csv(data_out, path = filepath)
   return(filepath)

--- a/2_process/src/process_and_style.R
+++ b/2_process/src/process_and_style.R
@@ -11,8 +11,7 @@ process_data <- function(all_site_files, site_filename) {
   return(nwis_data_processed)
 }
 
-hash_dir_files <- function(directory, dummy) {
-  files <- list.files(path = directory, full.names = TRUE, pattern = ".csv")
-  hash_vec <- tools::md5sum(files)
+hash_dir_files <- function(...) {
+  hash_vec <- tools::md5sum(c(...))
   data.frame(filepath = names(hash_vec), hash = hash_vec)
 }

--- a/2_process/src/process_and_style.R
+++ b/2_process/src/process_and_style.R
@@ -1,19 +1,18 @@
-process_data <- function(nwis_data){
-  nwis_data_clean <- rename(nwis_data, water_temperature = X_00010_00000) %>% 
-    select(-agency_cd, -X_00010_00000_cd, -tz_cd)
-  
-  return(nwis_data_clean)
-}
-
-annotate_data <- function(site_data_clean, site_filename){
+process_data <- function(all_site_files, site_filename) {
   site_info <- read_csv(site_filename)
-  annotated_data <- left_join(site_data_clean, site_info, by = "site_no") %>% 
-    select(station_name = station_nm, site_no, dateTime, water_temperature, latitude = dec_lat_va, longitude = dec_long_va)
+  nwis_data <- do.call(bind_rows, lapply(all_site_files$filepath, read_csv))
+  nwis_data_processed <- rename(nwis_data, water_temperature = X_00010_00000) %>% 
+    select(-agency_cd, -X_00010_00000_cd, -tz_cd) %>% 
+    left_join(site_info, by = "site_no") %>% 
+    select(station_name = station_nm, site_no, dateTime, water_temperature, 
+           latitude = dec_lat_va, longitude = dec_long_va) %>% 
+    mutate(station_name = as.factor(station_name))
   
-  return(annotated_data)
+  return(nwis_data_processed)
 }
 
-
-style_data <- function(site_data_annotated){
-  mutate(site_data_annotated, station_name = as.factor(station_name))
+hash_dir_files <- function(directory, dummy) {
+  files <- list.files(path = directory, full.names = TRUE, pattern = ".csv")
+  hash_vec <- tools::md5sum(files)
+  data.frame(filepath = names(hash_vec), hash = hash_vec)
 }

--- a/remake.yml
+++ b/remake.yml
@@ -15,21 +15,29 @@ targets:
   all:
     depends: 3_visualize/out/figure_1.png
 
-  site_data:
-    command: download_nwis_data()
-  
-  1_fetch/out/site_info.csv:
-    command: nwis_site_info(fileout = '1_fetch/out/site_info.csv', site_data)
+  1_fetch/out/site_data/01427207.csv:
+    command: download_nwis_site_data(target_name)
+  1_fetch/out/site_data/01432160.csv:
+    command: download_nwis_site_data(target_name)
+  1_fetch/out/site_data/01435000.csv:
+    command: download_nwis_site_data(target_name)
+  1_fetch/out/site_data/01436690.csv:
+    command: download_nwis_site_data(target_name)
+  1_fetch/out/site_data/01466500.csv:
+    command: download_nwis_site_data(target_name)
+    
+  all_site_files:
+    command: hash_dir_files(directory = I('1_fetch/out/site_data'), dummy = I('2020-07-01'))
+    depends:
+      - 1_fetch/out/site_data/01466500.csv
+      - 1_fetch/out/site_data/01436690.csv
+      - 1_fetch/out/site_data/01435000.csv
+      - 1_fetch/out/site_data/01432160.csv
+      - 1_fetch/out/site_data/01427207.csv
 
-  site_data_clean:
-    command: process_data(site_data)
-
-  site_data_annotated:
-    command: annotate_data(site_data_clean, site_filename = '1_fetch/out/site_info.csv')
-
-  site_data_styled:
-    command: style_data(site_data_annotated)	
+  site_data_processed:
+    command: process_data(all_site_files, site_filename = '1_fetch/out/site_info.csv')
 
   3_visualize/out/figure_1.png:
-    command: plot_nwis_timeseries(fileout = '3_visualize/out/figure_1.png', 
-      site_data_styled)  
+    command: plot_nwis_timeseries(fileout = target_name, 
+      site_data_processed)  

--- a/remake.yml
+++ b/remake.yml
@@ -15,26 +15,36 @@ targets:
   all:
     depends: 3_visualize/out/figure_1.png
 
+  fetch_date: 
+    command: c(I('2020-07-01'))
+
   1_fetch/out/site_data/01427207.csv:
     command: download_nwis_site_data(target_name)
+    depends: fetch_date
   1_fetch/out/site_data/01432160.csv:
     command: download_nwis_site_data(target_name)
+    depends: fetch_date
   1_fetch/out/site_data/01435000.csv:
     command: download_nwis_site_data(target_name)
+    depends: fetch_date
   1_fetch/out/site_data/01436690.csv:
     command: download_nwis_site_data(target_name)
+    depends: fetch_date
   1_fetch/out/site_data/01466500.csv:
     command: download_nwis_site_data(target_name)
+    depends: fetch_date
     
   all_site_files:
-    command: hash_dir_files(directory = I('1_fetch/out/site_data'), dummy = I('2020-07-01'))
-    depends:
-      - 1_fetch/out/site_data/01466500.csv
-      - 1_fetch/out/site_data/01436690.csv
-      - 1_fetch/out/site_data/01435000.csv
-      - 1_fetch/out/site_data/01432160.csv
-      - 1_fetch/out/site_data/01427207.csv
+    command: hash_dir_files('1_fetch/out/site_data/01466500.csv',
+       '1_fetch/out/site_data/01436690.csv',
+       '1_fetch/out/site_data/01435000.csv',
+       '1_fetch/out/site_data/01432160.csv',
+       '1_fetch/out/site_data/01427207.csv')
 
+  1_fetch/out/site_info.csv:	    
+    command: nwis_site_info(fileout = target_name, 
+       site_hash_table = all_site_files)
+    
   site_data_processed:
     command: process_data(all_site_files, site_filename = '1_fetch/out/site_info.csv')
 


### PR DESCRIPTION
My first thought here was to make the download step a single multi-site pull, so there would only be one web service call to pull the iv data, but I'm guessing that's not the object here? 😉 

Mainly the individual web service calls with 1/4 failure rate need to be separated into targets, otherwise the odds of finishing are quite poor.  I wanted to use the hash data frame approach here since I had not tried it before.  I suppose it isn't particularly necessary here, the individual site targets could just be passed into the processing step.  

The rest of the changes are fairly clear-cut—use target_names where possible, and combine the processing steps since they are trivial in terms of running time.  